### PR TITLE
Add new Style Guide template to incubator

### DIFF
--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -99,7 +99,7 @@ Also, avoid creating too many project-specific terms. Where possible, use the
 terms that are standard for your industry to avoid confusion. Ideally, you can
 inherit or defer to term definitions from a more authoritative glossary source.
 
-This section includes a table to highlight or call out any terms that are unique
+This section includes a table to highlight terms that are unique to your project,
 or which conflict with your default style guide. For example, the Google
 Developer's Guide uses "open source" but our project prefers "open-source" when
 used as a modifier, as in "open-source software."

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -68,7 +68,7 @@ you intend to use this style guide in your project. Feel free to adapt this
 content. If desired, you can briefly elaborate on the goals or mission of your
 project’s documentation.
 
-### About the "Our Preferred Style Guide" section
+### About the "Our preferred style guide" section
 
 Maintenance of a style guide is a lot of work. Try to do as little of it as
 possible by deferring to a more comprehensive default guide, such as the Google
@@ -80,7 +80,7 @@ from your default guide.
 Also, if your project already has existing brand guidelines, you can link to
 them or include them here.
 
-## About the "Glossary of Preferred Terms" section
+## About the "Glossary of preferred terms" section
 
 Every project has its own unique terms and buzzwords and this glossary can help
 you record your project’s preferred terms. This word list provides a list of
@@ -94,29 +94,29 @@ or which conflict with your default style guide. For example, the Google
 Developer's Guide uses "open source" but our project prefers "open-source" when
 used as a modifier, as in "open-source software."
 
-## About the "Topic Types and Templates" section
+## About the "Topic types and templates" section
 
 Depending on the type of project you’re creating, some of the Good Docs
 templates will be more relevant than others. In this section, you can link to
 the templates you have adopted for your project. You can also explain when
 contributors should use these templates.
 
-## About the "General Writing Tips" section
+## About the "General writing tips" section
 
 This section is optional. You can link to your favorite general writing tips or
 add some of your own general guidelines.
 
-## About the "Accessible Writing" section
+## About the "Accessible writing" section
 
 In this section, you can link to your preferred style guides about accessible
 writing or add some of your own general guidelines.
 
-## About the "Inclusive and Bias-Free Writing" section
+## About the "Inclusive and bias-free writing" section
 
 In this section, you can link to your favorite resources about inclusive and
 bias-free writing or add some of your own general guidelines.
 
-## About the "Using Linters" section
+## About the "Using linters" section
 
 This section is optional. [Linters](https://www.writethedocs.org/guide/tools/testing/#style-guide-checking-and-linting)
 are tools that analyze text content to flag common mistakes such as stylistic
@@ -135,12 +135,10 @@ documentation with less cognitive overhead.
 For resources and examples of linters, see:
 
 - [The `linter-google-styleguide` package for the Atom text editor](https://atom.io/packages/linter-google-styleguide)
-- A tool like [Vale](https://www.writethedocs.org/guide/tools/testing/#vale)
-  for a more automated approach, including styles such as the
-  [Microsoft Writing Style Guide](https://github.com/errata-ai/styles)
+- A tool like [Vale](https://www.writethedocs.org/guide/tools/testing/#vale),
+  which can automate [several popular styles](https://github.com/errata-ai/styles)
 
-
-## About the "How the Style Guide is Updated" section
+## About the "How the style guide is updated" section
 
 Indicate here how frequently your style guide is reviewed, who owns the style
 guide, and how contributors can provide feedback on your style guide. For
@@ -150,7 +148,7 @@ reviewed in project meetings.
 
 If this section is small enough, you can combine it with the following sections.
 
-## About the "Revision History" section
+## About the "Revision history" section
 
 This section is optional. You can use this section to provide a changelog or
 decision log of changes to your project’s style guide. You can also link out to
@@ -158,8 +156,7 @@ other project documents that contain your decision log. You could also use this
 section to provide guidelines about how to request changes to the style guide
 and outline how often decisions can be revisited (such as after a year).
 
-
-## About the "Decision Log" section
+## About the "Decision log" section
 
 This section is optional. Various project managers, sponsors, and teams make a
 lot of decisions while working on a project long-term. A decision log can track

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -13,16 +13,16 @@ important if different authors are contributing to the documentation over time.
 
 A style guide can provide early guidance to new contributors as they make
 decisions related to your project’s documentation. Contributors often have to
-make subjective judgment calls about the documentation, such as:
+make subjective decisions about the documentation, such as:
 
 - Which style guide your project will defer to as its default style guide
 - How to refer to terms that are unique or specific to that project
 - How to format certain types of content
 - What tone, attitude, or level of formality you recommend using in the project
   (usually conveyed through word choice)
-- Any specific rules you want to highlight or call out to documentation
-  contributors, such as language usage disputes that seem to arise periodically
-  within the community
+- Any specific rules you want to highlight for documentation contributors, such
+  as language usage disputes that seem to arise periodically within the
+  community
 
 A style guide provides your project’s answers to these questions and ensures
 that all of the contributors are working from the same common understanding.
@@ -85,7 +85,7 @@ them or include them here.
 Every project has its own unique terms and buzzwords and this glossary can help
 you record your project’s preferred terms. This word list provides a list of
 specific terms that are either common word choice problems or which are unique
-to our project. As a word of caution, try to minimize jargon and buzzwords.
+to your project. As a word of caution, try to minimize jargon and buzzwords.
 Also, avoid creating too many project-specific terms. Where possible, use the
 terms that are standard for your industry to avoid confusion.
 
@@ -103,7 +103,7 @@ contributors should use these templates.
 
 ## About the "General Writing Tips" section
 
-This seciton is optional. You can link to your favorite general writing tips or
+This section is optional. You can link to your favorite general writing tips or
 add some of your own general guidelines.
 
 ## About the "Accessible Writing" section

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -31,8 +31,8 @@ that all of the contributors are working from the same common understanding.
 
 A project's style guide usually starts out as a stub at the beginning of a
 project. For example, it might simply indicate which style guide is your
-project's default guide, such as the Google Developer's style guide or the
-Microsoft Manual of Style. It might link to specific elements from the default
+project's default guide, such as the Google developer documentation style guide
+or the Microsoft Style Guide. It might link to specific elements from the default
 guide that are most relevant to your project or point out any exceptions to the
 default guide.
 
@@ -81,10 +81,10 @@ documentation.
 
 Maintenance of a style guide is a lot of work. Try to do as little of it as
 possible by deferring to a more comprehensive default guide, such as the Google
-Developer's Style Guide or the Microsoft Manual of Style. In this section,
-you should indicate which guide is your default guide and reference the source
-document and its version. Document any exceptions where your style guide differs
-from your default guide.
+developer documentation style guide or the Microsoft Style Guide. In this
+section, you should indicate which guide is your default guide and reference the
+source document and its version. Document any exceptions where your style guide
+differs from your default guide.
 
 Also, if your project already has existing brand guidelines, you can link to
 them or include them here.
@@ -101,8 +101,8 @@ inherit or defer to term definitions from a more authoritative glossary source.
 
 This section includes a table to highlight terms that are unique to your project,
 or which conflict with your default style guide. For example, the Google
-Developer's Guide uses "open source" but our project prefers "open-source" when
-used as an adjective, as in "open-source software."
+developer documentation guide uses "open source" but our project prefers
+"open-source" when used as an adjective, as in "open-source software."
 
 ## About the "Topic types and templates" section
 

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -1,0 +1,168 @@
+# The style guide
+
+The style guide template itself occasionally includes placeholder text that
+is intended for you to replace with your own text. This text is indicated in
+{curly brackets}.
+
+## When do I need a style guide?
+
+A style guide provides project contributors with general guidelines for writing
+project documentation. The overall goal of a style guide is to ensure quality
+and consistency throughout the project’s documentation, which is especially
+important if different authors are contributing to the documentation over time.
+
+A style guide can provide early guidance to new contributors as they make
+decisions related to your project’s documentation. Contributors often have to
+make subjective judgment calls about the documentation, such as:
+
+- Which style guide your project will defer to as its default style guide
+- How to refer to terms that are unique or specific to that project
+- How to format certain types of content
+- What tone, attitude, or level of formality you recommend using in the project
+  (usually conveyed through word choice)
+- Any specific rules you want to highlight or call out to documentation
+  contributors, such as language usage disputes that seem to arise periodically
+  within the community
+
+A style guide provides your project’s answers to these questions and ensures
+that all of the contributors are working from the same common understanding.
+
+## How to make a style guide scale with your project
+
+A project’s style guide usually starts out as a stub at the beginning of a
+project. For example, it might simply indicate which style guide is your
+project’s default guide, such as the Google Developer’s style guide or the
+Microsoft Manual of Style. It might link to specific elements from the default
+guide that are most relevant to your project or point out any exceptions to the
+default guide.
+
+As your project grows and matures, your style guide can grow along with it. For
+example, debates can (and will) arise about how to refer to a specific term in
+the documentation, such as whether to capitalize or hyphenate a term that is
+unique to the project. Once resolved, you can capture decisions in the style
+guide. Then, if that debate arises again, you can simply refer contributors to
+your style guide rather than rehashing the same debate every time a new
+contributor joins the project.
+
+However, keep in mind that some teams consistently struggle to maintain a style
+guide over time. The guiding principle here is that a small amount of work up
+front can save a lot more work later. It’s much easier to set your standards in
+a style guide early in your project’s life cycle than it is to retroactively
+clean up your documentation later when the project is more mature. With small
+but regular updates, your style guide can evolve alongside your project. It will
+help your contributors get up to speed quickly and start writing high quality
+documentation.
+
+To help your project scale, consider setting a revolving meeting or agenda item
+to review the style guide and address style guide issues on a periodic basis
+(such as once a month). Perhaps you could make someone on the team the project
+owner for the style guide to ensure someone has the responsibility to update the
+guide after style guide reviews.
+
+## Content of your style guide
+
+### About the "Introduction" section
+
+In this section, you'll briefly introduce the purpose of the style guide and how
+you intend to use this style guide in your project. Feel free to adapt this
+content. If desired, you can briefly elaborate on the goals or mission of your
+project’s documentation.
+
+### About the "Our Preferred Style Guide" section
+
+Maintenance of a style guide is a lot of work. Try to do as little of it as
+possible by deferring to a more comprehensive default guide, such as the Google
+Developer's Style Guide or the Microsoft Manual of Style. In this section,
+you should indicate which guide is your default guide and reference the source
+document and its version. Document any exceptions where your style guide differs
+from your default guide.
+
+Also, if your project already has existing brand guidelines, you can link to
+them or include them here.
+
+## About the "Glossary of Preferred Terms" section
+
+Every project has its own unique terms and buzzwords and this glossary can help
+you record your project’s preferred terms. This word list provides a list of
+specific terms that are either common word choice problems or which are unique
+to our project. As a word of caution, try to minimize jargon and buzzwords.
+Also, avoid creating too many project-specific terms. Where possible, use the
+terms that are standard for your industry to avoid confusion.
+
+This section includes a table to highlight or call out any terms that are unique
+or which conflict with your default style guide. For example, the Google
+Developer's Guide uses "open source" but our project prefers "open-source" when
+used as a modifier, as in "open-source software."
+
+## About the "Topic Types and Templates" section
+
+Depending on the type of project you’re creating, some of the Good Docs
+templates will be more relevant than others. In this section, you can link to
+the templates you have adopted for your project. You can also explain when
+contributors should use these templates.
+
+## About the "General Writing Tips" section
+
+This seciton is optional. You can link to your favorite general writing tips or
+add some of your own general guidelines.
+
+## About the "Accessible Writing" section
+
+In this section, you can link to your preferred style guides about accessible
+writing or add some of your own general guidelines.
+
+## About the "Inclusive and Bias-Free Writing" section
+
+In this section, you can link to your favorite resources about inclusive and
+bias-free writing or add some of your own general guidelines.
+
+## About the "Using Linters" section
+
+This section is optional. [Linters](https://www.writethedocs.org/guide/tools/testing/#style-guide-checking-and-linting)
+are tools that analyze text content to flag common mistakes such as stylistic
+errors and suspicious constructs. An example of a linter would be a tool like
+Grammarly that processes your text and provides suggestions as you write to
+improve the spelling and grammatical structure of the text.
+
+Linters can be used during the editorial process within an editor and as a
+post-processing test of the content when the document is pushed into a revision
+management system as part of an automated continuous integration (CI) cycle.
+
+If you want to take your style guide to the next level, you could adopt a linter
+to enforce your style guide and empower your content creators to make better
+documentation with less cognitive overhead.
+
+For resources and examples of linters, see:
+
+- [The Atom editor’s Google Linter app](https://atom.io/packages/linter-google-styleguide)
+- A tool like [Vale](https://www.writethedocs.org/guide/tools/testing/#vale)
+  for a more automated approach, including styles such as the
+  [Microsoft Writing Style Guide](https://github.com/errata-ai/styles)
+
+
+## About the "How the Style Guide is Updated" section
+
+Indicate here how frequently your style guide is reviewed, who owns the style
+guide, and how contributors can provide feedback on your style guide. For
+example, you could provide the contact information for the group or individual
+who owns the style guide. You could also indicate when the style guide is
+reviewed in project meetings.
+
+If this section is small enough, you can combine it with the following sections.
+
+## About the "Revision History" section
+
+This section is optional. You can use this section to provide a changelog or
+decision log of changes to your project’s style guide. You can also link out to
+other project documents that contain your decision log. You could also use this
+section to provide guidelines about how to request changes to the style guide
+and outline how often decisions can be revisited (such as after a year).
+
+
+## About the "Decision Log" section
+
+This section is optional. Various project managers, sponsors, and teams make a
+lot of decisions while working on a project long-term. A decision log can track
+the decisions you’ve agreed upon. A decision log lists the key decisions made on
+the project. If your project has a separate decision log, you can link to it or
+provide one here.

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -63,7 +63,7 @@ guide after style guide reviews.
 
 ### About the "Introduction" section
 
-In this section, you'll briefly introduce the purpose of the style guide and how
+In this section, briefly introduce the purpose of the style guide and how
 you intend to use this style guide in your project. Feel free to adapt this
 content. If desired, you can briefly elaborate on the goals or mission of your
 project’s documentation.

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -134,7 +134,7 @@ documentation with less cognitive overhead.
 
 For resources and examples of linters, see:
 
-- [The Atom editor’s Google Linter app](https://atom.io/packages/linter-google-styleguide)
+- [The `linter-google-styleguide` package for the Atom text editor](https://atom.io/packages/linter-google-styleguide)
 - A tool like [Vale](https://www.writethedocs.org/guide/tools/testing/#vale)
   for a more automated approach, including styles such as the
   [Microsoft Writing Style Guide](https://github.com/errata-ai/styles)

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -134,7 +134,7 @@ errors and suspicious constructs. An example of a linter would be a tool like
 Grammarly that processes your text and provides suggestions as you write to
 improve the spelling and grammatical structure of the text.
 
-Linters can be used during the editorial process within an editor and as a
+Linters can be used during the editorial process within a text editor and as a
 post-processing test of the content when the document is pushed into a revision
 management system as part of an automated continuous integration (CI) cycle.
 

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -53,7 +53,7 @@ but regular updates, your style guide can evolve alongside your project. It will
 help your contributors get up to speed quickly and start writing high quality
 documentation.
 
-To help your project scale, consider setting a revolving meeting or agenda item
+To help your project scale, consider setting a recurring meeting or agenda item
 to review the style guide and address style guide issues on a periodic basis
 (such as once a month). Perhaps you could make someone on the team the project
 owner for the style guide to ensure someone has the responsibility to update the
@@ -67,6 +67,15 @@ In this section, you'll briefly introduce the purpose of the style guide and how
 you intend to use this style guide in your project. Feel free to adapt this
 content. If desired, you can briefly elaborate on the goals or mission of your
 project’s documentation.
+
+### About the "Intended audience and scope" section
+
+Use this section to indicate who should use this style guide. Describe your
+audience for the style guide, which includes all the people who write your
+documentation. You will know them best. They typically will include software
+engineers, product mangers, and tech writers, etc. You can also indicate the
+scope of the style guide if it should include more than just your project's
+documentation.
 
 ### About the "Our preferred style guide" section
 
@@ -87,7 +96,8 @@ you record your project’s preferred terms. This word list provides a list of
 specific terms that are either common word choice problems or which are unique
 to your project. As a word of caution, try to minimize jargon and buzzwords.
 Also, avoid creating too many project-specific terms. Where possible, use the
-terms that are standard for your industry to avoid confusion.
+terms that are standard for your industry to avoid confusion. Ideally, you can
+inherit or defer to term definitions from a more authoritative glossary source.
 
 This section includes a table to highlight or call out any terms that are unique
 or which conflict with your default style guide. For example, the Google
@@ -155,6 +165,14 @@ decision log of changes to your project’s style guide. You can also link out t
 other project documents that contain your decision log. You could also use this
 section to provide guidelines about how to request changes to the style guide
 and outline how often decisions can be revisited (such as after a year).
+
+To choose the edition number for the style guide, consider using the
+Major.Minor.Patch numbering system outlined in
+[Semantic Versioning 2.0.0](https://semver.org/). When these
+guidelines are applied to documents, you typically use 0.1 through 0.9 for
+drafts. After the first release of the document, switch to 1.0. For major
+revisions, increase the version by a full numeral such as 2.0. For minor
+revisions, add a decimal, such as 1.1.
 
 ## About the "Decision log" section
 

--- a/style-guide/about-style-guide.md
+++ b/style-guide/about-style-guide.md
@@ -8,11 +8,11 @@ is intended for you to replace with your own text. This text is indicated in
 
 A style guide provides project contributors with general guidelines for writing
 project documentation. The overall goal of a style guide is to ensure quality
-and consistency throughout the project’s documentation, which is especially
+and consistency throughout the project's documentation, which is especially
 important if different authors are contributing to the documentation over time.
 
 A style guide can provide early guidance to new contributors as they make
-decisions related to your project’s documentation. Contributors often have to
+decisions related to your project's documentation. Contributors often have to
 make subjective decisions about the documentation, such as:
 
 - Which style guide your project will defer to as its default style guide
@@ -24,14 +24,14 @@ make subjective decisions about the documentation, such as:
   as language usage disputes that seem to arise periodically within the
   community
 
-A style guide provides your project’s answers to these questions and ensures
+A style guide provides your project's answers to these questions and ensures
 that all of the contributors are working from the same common understanding.
 
 ## How to make a style guide scale with your project
 
-A project’s style guide usually starts out as a stub at the beginning of a
+A project's style guide usually starts out as a stub at the beginning of a
 project. For example, it might simply indicate which style guide is your
-project’s default guide, such as the Google Developer’s style guide or the
+project's default guide, such as the Google Developer's style guide or the
 Microsoft Manual of Style. It might link to specific elements from the default
 guide that are most relevant to your project or point out any exceptions to the
 default guide.
@@ -46,8 +46,8 @@ contributor joins the project.
 
 However, keep in mind that some teams consistently struggle to maintain a style
 guide over time. The guiding principle here is that a small amount of work up
-front can save a lot more work later. It’s much easier to set your standards in
-a style guide early in your project’s life cycle than it is to retroactively
+front can save a lot more work later. It's much easier to set your standards in
+a style guide early in your project's life cycle than it is to retroactively
 clean up your documentation later when the project is more mature. With small
 but regular updates, your style guide can evolve alongside your project. It will
 help your contributors get up to speed quickly and start writing high quality
@@ -66,7 +66,7 @@ guide after style guide reviews.
 In this section, you'll briefly introduce the purpose of the style guide and how
 you intend to use this style guide in your project. Feel free to adapt this
 content. If desired, you can briefly elaborate on the goals or mission of your
-project’s documentation.
+project's documentation.
 
 ### About the "Intended audience and scope" section
 
@@ -92,7 +92,7 @@ them or include them here.
 ## About the "Glossary of preferred terms" section
 
 Every project has its own unique terms and buzzwords and this glossary can help
-you record your project’s preferred terms. This word list provides a list of
+you record your project's preferred terms. This word list provides a list of
 specific terms that are either common word choice problems or which are unique
 to your project. As a word of caution, try to minimize jargon and buzzwords.
 Also, avoid creating too many project-specific terms. Where possible, use the
@@ -102,14 +102,15 @@ inherit or defer to term definitions from a more authoritative glossary source.
 This section includes a table to highlight or call out any terms that are unique
 or which conflict with your default style guide. For example, the Google
 Developer's Guide uses "open source" but our project prefers "open-source" when
-used as a modifier, as in "open-source software."
+used as an adjective, as in "open-source software."
 
 ## About the "Topic types and templates" section
 
-Depending on the type of project you’re creating, some of the Good Docs
-templates will be more relevant than others. In this section, you can link to
-the templates you have adopted for your project. You can also explain when
-contributors should use these templates.
+The Good Docs project provides templates for various types of topics that you
+can adopt in your project. Depending on the type of project you're creating,
+some of the Good Docs templates will be more relevant than others. In this
+section, you can link to the templates you have adopted for your project. You
+can also explain when contributors should use these templates.
 
 ## About the "General writing tips" section
 
@@ -130,13 +131,18 @@ bias-free writing or add some of your own general guidelines.
 
 This section is optional. [Linters](https://www.writethedocs.org/guide/tools/testing/#style-guide-checking-and-linting)
 are tools that analyze text content to flag common mistakes such as stylistic
-errors and suspicious constructs. An example of a linter would be a tool like
-Grammarly that processes your text and provides suggestions as you write to
-improve the spelling and grammatical structure of the text.
+errors and suspicious constructs. They are helpful for enforcing your style
+guide by checking constributions for style guide consistency. An example of a
+linter would be a tool like Grammarly that processes your text and provides
+suggestions as you write to improve the spelling and grammatical structure of
+the text.
 
-Linters can be used during the editorial process within an editor and as a
-post-processing test of the content when the document is pushed into a revision
-management system as part of an automated continuous integration (CI) cycle.
+Linters can be used at two different points when creating documentation:
+- **During the editorial process** - Typically used within a text editor, a
+  linter can check for style consistency while composing documentation.
+- **As a post-processing test** - When the content is pushed into a revision
+  management system as part of an automated continuous integration (CI) cycle,
+  a linter can evaluate text for style consistency.
 
 If you want to take your style guide to the next level, you could adopt a linter
 to enforce your style guide and empower your content creators to make better
@@ -147,6 +153,8 @@ For resources and examples of linters, see:
 - [The `linter-google-styleguide` package for the Atom text editor](https://atom.io/packages/linter-google-styleguide)
 - A tool like [Vale](https://www.writethedocs.org/guide/tools/testing/#vale),
   which can automate [several popular styles](https://github.com/errata-ai/styles)
+- The [Alex](https://alexjs.com/) linter can check for insensitive and
+  inconsiderate writing.
 
 ## About the "How the style guide is updated" section
 
@@ -161,7 +169,7 @@ If this section is small enough, you can combine it with the following sections.
 ## About the "Revision history" section
 
 This section is optional. You can use this section to provide a changelog or
-decision log of changes to your project’s style guide. You can also link out to
+decision log of changes to your project's style guide. You can also link out to
 other project documents that contain your decision log. You could also use this
 section to provide guidelines about how to request changes to the style guide
 and outline how often decisions can be revisited (such as after a year).
@@ -178,6 +186,6 @@ revisions, add a decimal, such as 1.1.
 
 This section is optional. Various project managers, sponsors, and teams make a
 lot of decisions while working on a project long-term. A decision log can track
-the decisions you’ve agreed upon. A decision log lists the key decisions made on
+the decisions you've agreed upon. A decision log lists the key decisions made on
 the project. If your project has a separate decision log, you can link to it or
 provide one here.

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -75,7 +75,7 @@ helps make documentation clearer and more useful for everyone.
 
 For resources on making your writing more accessible, see:
 
-- [Writing accessible documentation - Google Developer’s Style Guide](https://developers.google.com/style/accessibility)
+- [Writing accessible documentation - Google developer documentation style guide](https://developers.google.com/style/accessibility)
 - [Accessibility guidelines and requirements - Microsoft Manual of Style](https://docs.microsoft.com/en-us/style-guide/accessibility/accessibility-guidelines-requirements)
 - [Writing for Accessibility - MailChimp Content Style Guide](https://styleguide.mailchimp.com/writing-for-accessibility/)
 

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -1,0 +1,132 @@
+<!-- Copy this Template. -->
+<!-- Change the name of your project, such as "Good Docs style guide". -->
+# Style guide template
+
+<!-- Before using this template, please read the accompanying About the
+Style Guide Template documentation. -->
+
+## Introduction
+
+Welcome to our project! This style guide is intended for use by project
+contributors, not necessarily end-users. It provides general guidance to anyone
+who contributes to the project’s documentation.
+
+## Our Preferred Style Guide
+
+We have adopted the
+[your preferred style guide, such as the Google Developer's Style Guide](https://developers.google.com/style)
+for {Your Project} documentation. For a quick summary, see the
+[Google style guide highlights](https://developers.google.com/style/highlights).
+The rest of this document describes our project-specific customizations to
+{Google's or your preferred} guide.
+
+Our project uses {your choice: standard American spelling or standard British
+spelling, etc.} and our preferred dictionary is the
+{[American Heritage Dictionary](https://ahdictionary.com/) or your preferred
+dictionary}.
+
+When writing documentation for our project, align with the default guide’s
+voice and tone.
+
+## Glossary of Preferred Terms
+
+<!-- This first paragraph is optional or you could include in the word list. -->
+
+This {Your Project Name} is represented as {example}. It is {always/never}
+capitalized.
+
+The table provides guidelines about the terms you should and should not use for
+consistency, listed in alphabetical order:
+
+Preferred Term  | Avoid These Terms  |  Explanation
+--------------- | -----------------  |  -----------
+for example     | e.g.               |  Avoid non-English words
+people with disabilities  | <ul><li>the disabled</li><li>disabled people</li><li>people with handicaps</li><li>the handicapped</li></ul>  |  Use inclusive and bias-free language. See [Accessible Writing](#accessible-writing
+that is         |  i.e.              |  Avoid non-English words
+
+## Topic Types and Templates
+
+This project recommends using the following templates from the
+[Good Docs project](https://github.com/thegooddocsproject/templates):
+
+- API Overview
+- API Quickstart
+- API Reference
+- Discussion Article
+- How To Guide
+- Logging Article
+- Reference Article
+- Tutorial
+
+## General Writing Tips
+
+<!-- This section is optional -->
+
+For some general tips about improving writing see:
+
+- [Write the Docs - Style Guides](https://www.writethedocs.org/guide/writing/style-guides/#writing-style)
+- [18F Content Guide](https://content-guide.18f.gov/)
+
+## Accessible Writing
+
+Documentation should be written in a way that supports people with disabilities
+and users with various input methods and devices. Improving accessibility also
+helps make documentation clearer and more useful for everyone.
+
+For resources on making your writing more accessible, see:
+
+- [Writing accessible documentation - Google Developer’s Style Guide](https://developers.google.com/style/accessibility)
+- [Accessibility guidelines and requirements - Microsoft Manual of Style](https://docs.microsoft.com/en-us/style-guide/accessibility/accessibility-guidelines-requirements)
+- [Writing for Accessibility - MailChimp Content Style Guide](https://styleguide.mailchimp.com/writing-for-accessibility/)
+
+## Inclusive and Bias-Free Writing
+
+When contributing to this project, you should strive to write documentation with
+inclusivity and diversity in mind. Inclusive language recognizes diversity and
+strives to communicate respectfully to all people. This kind of language is
+sensitive to differences and seeks to promote equal opportunities.
+
+For resources on making your writing more inclusive, see:
+
+- [Inclusive documentation - Google Developer’s Style Guide](https://developers.google.com/style/inclusive-documentation)
+- [The Conscious Style Guide - a collection of resources](https://consciousstyleguide.com/)
+- [Bias-free communication - Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
+- [Guidelines for Inclusive Language - Linguistic Society of America](https://www.linguisticsociety.org/resource/guidelines-inclusive-language)
+
+## Using Linters
+
+<!-- This section is optional -->
+
+This project uses the {your preferred linter.}
+
+<!-- Provide instructions or policies related to the linter here. -->
+
+## How the style guide is updated
+
+<!-- Indicate here how frequently your style guide is reviewed, who owns the
+style guide, and how contributors can provide feedback on your style guide. -->
+
+## Revision History
+
+<!-- This section is optional -->
+
+The following table describes the history of all decisions and revisions made to
+this style guide over time. For style guide drafts, use 0.1 through 0.9. After
+the first release of the document, switch to 1.0. For major revisions, increase
+the version by a full numeral such as 2.0. For minor revisions, add a decimal,
+such as 1.1.
+
+Edition  |  Date      |  Lead Author(s)    |  Link to Repository Commit/Tag
+-------  |  ----      |  --------------    |  -----------------------------
+{0.1}    |  {1/1/11}  |  {Your name here}  |  First draft of Style Guide
+
+
+## Decision Log
+
+The following table describes the history of all decisions made to this style
+guide over time.
+
+
+Ref  |  Date     |  Description                               |  Agreed to by
+---  |  ----     |  -----------                               |  ------------
+1    | {1/1/11}  |  {Explain the decision that was made here} |  {Name or role}

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -10,7 +10,7 @@ Template documentation.}
 
 Welcome to our project! This style guide is intended for use by project
 contributors, not necessarily end-users. It provides general guidance to anyone
-who contributes to the project’s documentation.
+who contributes to the project's documentation.
 
 ## Intended audience and scope
 
@@ -34,7 +34,7 @@ spelling, etc.} and our preferred dictionary is the
 {[American Heritage Dictionary](https://ahdictionary.com/) or your preferred
 dictionary}.
 
-When writing documentation for our project, align with the default guide’s
+When writing documentation for our project, align with the default guide's
 voice and tone.
 
 ## Glossary of preferred terms
@@ -97,7 +97,7 @@ sensitive to differences and seeks to promote equal opportunities.
 
 For resources on making your writing more inclusive, see:
 
-- [Inclusive documentation - Google developer’s style guide](https://developers.google.com/style/inclusive-documentation)
+- [Inclusive documentation - Google developer's style guide](https://developers.google.com/style/inclusive-documentation)
 - [The Conscious Style Guide - a collection of resources](https://consciousstyleguide.com/)
 - [Bias-free communication - Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
 - [Guidelines for Inclusive Language - Linguistic Society of America](https://www.linguisticsociety.org/resource/guidelines-inclusive-language)

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -76,7 +76,7 @@ helps make documentation clearer and more useful for everyone.
 For resources on making your writing more accessible, see:
 
 - [Writing accessible documentation - Google developer documentation style guide](https://developers.google.com/style/accessibility)
-- [Accessibility guidelines and requirements - Microsoft Manual of Style](https://docs.microsoft.com/en-us/style-guide/accessibility/accessibility-guidelines-requirements)
+- [Accessibility guidelines and requirements - Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/accessibility/accessibility-guidelines-requirements)
 - [Writing for Accessibility - Mailchimp Content Style Guide](https://styleguide.mailchimp.com/writing-for-accessibility/)
 
 ## Inclusive and Bias-Free Writing

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -77,7 +77,7 @@ For resources on making your writing more accessible, see:
 
 - [Writing accessible documentation - Google developer documentation style guide](https://developers.google.com/style/accessibility)
 - [Accessibility guidelines and requirements - Microsoft Manual of Style](https://docs.microsoft.com/en-us/style-guide/accessibility/accessibility-guidelines-requirements)
-- [Writing for Accessibility - MailChimp Content Style Guide](https://styleguide.mailchimp.com/writing-for-accessibility/)
+- [Writing for Accessibility - Mailchimp Content Style Guide](https://styleguide.mailchimp.com/writing-for-accessibility/)
 
 ## Inclusive and Bias-Free Writing
 

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -1,20 +1,29 @@
-<!-- Copy this Template. -->
-<!-- Change the name of your project, such as "Good Docs style guide". -->
-# Style guide template
 
-<!-- Before using this template, please read the accompanying About the
-Style Guide Template documentation. -->
+# {Your Project Name} style guide
+
+{Version number and last updated date}
 
 ## Introduction
+
+{Before using this template, please read the accompanying About the Style Guide
+Template documentation.}
 
 Welcome to our project! This style guide is intended for use by project
 contributors, not necessarily end-users. It provides general guidance to anyone
 who contributes to the project’s documentation.
 
+## Intended audience and scope
+
+This style guide is intended for use by any contributors that are writing
+documentation for {Your Project Name}, including software engineers. This guide
+can help project contributors to communicate clearly and consistently in {you
+define the scope: the project's end-user documentation, API documentation,
+forum posts, and so forth.}
+
 ## Our preferred style guide
 
 We have adopted the
-[your preferred style guide, such as the Google developer's style guide](https://developers.google.com/style)
+{[your preferred style guide, such as the Google developer's style guide](https://developers.google.com/style)}
 for {Your Project} documentation. For a quick summary, see the
 [Google style guide highlights](https://developers.google.com/style/highlights).
 The rest of this document describes our project-specific customizations to
@@ -30,7 +39,7 @@ voice and tone.
 
 ## Glossary of preferred terms
 
-<!-- This first paragraph is optional or you could include in the word list. -->
+{This first paragraph is optional or you could include in the word list.}
 
 This {Your Project Name} is represented as {example}. It is {always/never}
 capitalized.
@@ -60,7 +69,7 @@ This project recommends using the following templates from the
 
 ## General writing tips
 
-<!-- This section is optional -->
+{This section is optional.}
 
 For some general tips about improving writing see:
 
@@ -95,26 +104,24 @@ For resources on making your writing more inclusive, see:
 
 ## Using linters
 
-<!-- This section is optional -->
+{This section is optional.}
 
 This project uses the {your preferred linter.}
 
-<!-- Provide instructions or policies related to the linter here. -->
+{Provide instructions or policies related to the linter here.}
 
 ## How the style guide is updated
 
-<!-- Indicate here how frequently your style guide is reviewed, who owns the
-style guide, and how contributors can provide feedback on your style guide. -->
+{Indicate here how frequently your style guide is reviewed, who owns the style
+guide, and how contributors can provide feedback on your style guide.}
 
 ## Revision history
 
-<!-- This section is optional -->
+{This section is optional or can be combined with the next section if needed.}
 
 The following table describes the history of all decisions and revisions made to
-this style guide over time. For style guide drafts, use 0.1 through 0.9. After
-the first release of the document, switch to 1.0. For major revisions, increase
-the version by a full numeral such as 2.0. For minor revisions, add a decimal,
-such as 1.1.
+this style guide over time. This guide uses the Major.Minor.Patch
+[semantic versioning](https://semver.org/) convention.
 
 Edition  |  Date      |  Lead Author(s)    |  Link to Repository Commit/Tag
 -------  |  ----      |  --------------    |  -----------------------------
@@ -123,8 +130,11 @@ Edition  |  Date      |  Lead Author(s)    |  Link to Repository Commit/Tag
 
 ## Decision log
 
+{This section is optional or can be combined with the previous section if
+needed.}
+
 The following table describes the history of all decisions made to this style
-guide over time.
+guide over time:
 
 Ref  |  Date     |  Description                               |  Agreed to by
 ---  |  ----     |  -----------                               |  ------------

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -11,10 +11,10 @@ Welcome to our project! This style guide is intended for use by project
 contributors, not necessarily end-users. It provides general guidance to anyone
 who contributes to the project’s documentation.
 
-## Our Preferred Style Guide
+## Our preferred style guide
 
 We have adopted the
-[your preferred style guide, such as the Google Developer's Style Guide](https://developers.google.com/style)
+[your preferred style guide, such as the Google developer's style guide](https://developers.google.com/style)
 for {Your Project} documentation. For a quick summary, see the
 [Google style guide highlights](https://developers.google.com/style/highlights).
 The rest of this document describes our project-specific customizations to
@@ -28,7 +28,7 @@ dictionary}.
 When writing documentation for our project, align with the default guide’s
 voice and tone.
 
-## Glossary of Preferred Terms
+## Glossary of preferred terms
 
 <!-- This first paragraph is optional or you could include in the word list. -->
 
@@ -41,10 +41,10 @@ consistency, listed in alphabetical order:
 Preferred Term  | Avoid These Terms  |  Explanation
 --------------- | -----------------  |  -----------
 for example     | e.g.               |  Avoid non-English words
-people with disabilities  | <ul><li>the disabled</li><li>disabled people</li><li>people with handicaps</li><li>the handicapped</li></ul>  |  Use inclusive and bias-free language. See [Accessible Writing](#accessible-writing
+people with disabilities  | <ul><li>the disabled</li><li>disabled people</li><li>people with handicaps</li><li>the handicapped</li></ul>  |  Use inclusive and bias-free language. See [Accessible Writing](#accessible-writing)
 that is         |  i.e.              |  Avoid non-English words
 
-## Topic Types and Templates
+## Topic types and templates
 
 This project recommends using the following templates from the
 [Good Docs project](https://github.com/thegooddocsproject/templates):
@@ -58,7 +58,7 @@ This project recommends using the following templates from the
 - Reference Article
 - Tutorial
 
-## General Writing Tips
+## General writing tips
 
 <!-- This section is optional -->
 
@@ -67,7 +67,7 @@ For some general tips about improving writing see:
 - [Write the Docs - Style Guides](https://www.writethedocs.org/guide/writing/style-guides/#writing-style)
 - [18F Content Guide](https://content-guide.18f.gov/)
 
-## Accessible Writing
+## Accessible writing
 
 Documentation should be written in a way that supports people with disabilities
 and users with various input methods and devices. Improving accessibility also
@@ -79,7 +79,7 @@ For resources on making your writing more accessible, see:
 - [Accessibility guidelines and requirements - Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/accessibility/accessibility-guidelines-requirements)
 - [Writing for Accessibility - Mailchimp Content Style Guide](https://styleguide.mailchimp.com/writing-for-accessibility/)
 
-## Inclusive and Bias-Free Writing
+## Inclusive and bias-free writing
 
 When contributing to this project, you should strive to write documentation with
 inclusivity and diversity in mind. Inclusive language recognizes diversity and
@@ -88,12 +88,12 @@ sensitive to differences and seeks to promote equal opportunities.
 
 For resources on making your writing more inclusive, see:
 
-- [Inclusive documentation - Google Developer’s Style Guide](https://developers.google.com/style/inclusive-documentation)
+- [Inclusive documentation - Google developer’s style guide](https://developers.google.com/style/inclusive-documentation)
 - [The Conscious Style Guide - a collection of resources](https://consciousstyleguide.com/)
-- [Bias-free communication - Microsoft Style Guide](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
+- [Bias-free communication - Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
 - [Guidelines for Inclusive Language - Linguistic Society of America](https://www.linguisticsociety.org/resource/guidelines-inclusive-language)
 
-## Using Linters
+## Using linters
 
 <!-- This section is optional -->
 
@@ -106,7 +106,7 @@ This project uses the {your preferred linter.}
 <!-- Indicate here how frequently your style guide is reviewed, who owns the
 style guide, and how contributors can provide feedback on your style guide. -->
 
-## Revision History
+## Revision history
 
 <!-- This section is optional -->
 
@@ -121,11 +121,10 @@ Edition  |  Date      |  Lead Author(s)    |  Link to Repository Commit/Tag
 {0.1}    |  {1/1/11}  |  {Your name here}  |  First draft of Style Guide
 
 
-## Decision Log
+## Decision log
 
 The following table describes the history of all decisions made to this style
 guide over time.
-
 
 Ref  |  Date     |  Description                               |  Agreed to by
 ---  |  ----     |  -----------                               |  ------------

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -23,7 +23,7 @@ forum posts, and so forth.}
 ## Our preferred style guide
 
 We have adopted the
-{[your preferred style guide, such as the Google developer's style guide](https://developers.google.com/style)}
+{[your preferred style guide, such as the Google developer documentation style guide](https://developers.google.com/style)}
 for {Your Project} documentation. For a quick summary, see the
 [Google style guide highlights](https://developers.google.com/style/highlights).
 The rest of this document describes our project-specific customizations to
@@ -97,7 +97,7 @@ sensitive to differences and seeks to promote equal opportunities.
 
 For resources on making your writing more inclusive, see:
 
-- [Inclusive documentation - Google developer's style guide](https://developers.google.com/style/inclusive-documentation)
+- [Inclusive documentation - Google developer documentation style guide](https://developers.google.com/style/inclusive-documentation)
 - [The Conscious Style Guide - a collection of resources](https://consciousstyleguide.com/)
 - [Bias-free communication - Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
 - [Guidelines for Inclusive Language - Linguistic Society of America](https://www.linguisticsociety.org/resource/guidelines-inclusive-language)

--- a/style-guide/template-style-guide.md
+++ b/style-guide/template-style-guide.md
@@ -39,7 +39,7 @@ voice and tone.
 
 ## Glossary of preferred terms
 
-{This first paragraph is optional or you could include in the word list.}
+{Calling out how to write your project name first is optional. You can choose to include your project name in the word list instead.}
 
 This {Your Project Name} is represented as {example}. It is {always/never}
 capitalized.


### PR DESCRIPTION
This PR submits a template for a Style Guide. It includes a folder containing two files that I've tried to mirror from the :

- **About the Style Guide** - A description of the style guide and its sections for users who want to adopt the template.
- **Style Guide Template** - The actual template for use with the guide.

NOTE: I'm not familiar with how we best indicate placeholder text in this project, but I'm beginning to have a preference for {curly braces}. If you want me to swap out my placeholder curly braces for something else, please let me know.

I want to also mention that this template has already undergone extensive reviews from members of the Good Docs community as well as the Write the Docs community over the last few months. The original document was a Google Docs document: [Style Guide Template](https://docs.google.com/document/d/1HxtaiayAJZvF0ZfNjLvRH3vYMvGTEki_TK8hFilQNJ0/edit?usp=sharing).